### PR TITLE
[bugfix] crashing output bug

### DIFF
--- a/lib/crow-output.lua
+++ b/lib/crow-output.lua
@@ -23,7 +23,7 @@ end
 function CrowOutput:play_note(note)
   local cycle_min = params:get('cycle_min')
 
-  if parameters.quantizer_note_snap == true then 
+  if parameters.quantizer_note_snap == true and note:get('quantized_note_number') then 
     crow.output[1].volts = (note:get('quantized_note_number') - params:get('root')) / 12
   else
     crow.output[1].volts = (note:get('initial_note_number') - params:get('root')) / 12

--- a/lib/disting-output.lua
+++ b/lib/disting-output.lua
@@ -16,7 +16,7 @@ function DistingOutput:play_note(note)
     function()
       local id = note:get('quantized_note_number') or note:get('initial_note_number')
 
-      if parameters.quantizer_note_snap == true then 
+      if parameters.quantizer_note_snap == true  and note:get('quantized_note_number') then 
         crow.ii.disting.note_pitch(id, (note:get('quantized_note_number') - params:get('root')) / 12)
       else
         crow.ii.disting.note_pitch(id, (note:get('initial_note_number') - params:get('root')) / 12)

--- a/lib/jf-output.lua
+++ b/lib/jf-output.lua
@@ -18,7 +18,7 @@ function JFOutput:init()
 end
 
 function JFOutput:play_note(note)
-  if parameters.quantizer_note_snap == true then 
+  if parameters.quantizer_note_snap == true and note:get('quantized_note_number') then 
     crow.ii.jf.play_note((note:get('quantized_note_number') - params:get('root')) / 12, 5)
   else
     crow.ii.jf.play_note((note:get('initial_note_number') - params:get('root')) / 12, 5)

--- a/lib/wslashsynth-output.lua
+++ b/lib/wslashsynth-output.lua
@@ -16,7 +16,7 @@ function WSlashSynthOutput:init()
 end
 
 function WSlashSynthOutput:play_note(note)
-  if parameters.quantizer_note_snap == true then 
+  if parameters.quantizer_note_snap == true and note:get('quantized_note_number') then 
     crow.ii.wsyn.play_note((note:get('quantized_note_number')  - params:get('root'))/ 12, 5)
   else
     crow.ii.wsyn.play_note((note:get('initial_note_number')  - params:get('root'))/ 12, 5)


### PR DESCRIPTION
When switching between unquantized and quantized notes several outputs were not checking for the existence of a quantized note before performing it and crashing the script.